### PR TITLE
Revert "Run PostCSS plugin to remove redundant media queries during production build"

### DIFF
--- a/ui.apps/src/main/webpack.core/internals/webpack.config.js
+++ b/ui.apps/src/main/webpack.core/internals/webpack.config.js
@@ -55,10 +55,7 @@ const WEBPACK_DEFAULT = {
             plugins: (loader) => {
               const plugins = [];
 
-              if (IS_PROD) {
-                // "css-mqpacker" packs same CSS media query rules into one
-                plugins.push(require('css-mqpacker'));
-              } else {
+              if (!IS_PROD) {
                 plugins.push(require('stylelint')({
                   configFile: path.resolve(__dirname, './stylelint.config.js'),
                   fix: true,

--- a/ui.apps/src/main/webpack.core/package-lock.json
+++ b/ui.apps/src/main/webpack.core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-core",
-  "version": "2.2.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2470,24 +2470,6 @@
           "requires": {
             "has-flag": "1.0.0"
           }
-        }
-      }
-    },
-    "css-mqpacker": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/css-mqpacker/-/css-mqpacker-6.0.1.tgz",
-      "integrity": "sha512-pQ40tp4ooLopvkYA8YfQdDAAnoPToP5a3tdOWn6A4VwaJ6tGJLvyC3UEfmfsw9DbX2Ofgk4WBIVW3EZmNYvLYQ==",
-      "dev": true,
-      "requires": {
-        "minimist": "1.2.0",
-        "postcss": "6.0.6"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
         }
       }
     },

--- a/ui.apps/src/main/webpack.core/package.json
+++ b/ui.apps/src/main/webpack.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-core",
-  "version": "2.2.0",
+  "version": "2.1.1",
   "private": true,
   "description": "Core front end setup of a project",
   "scripts": {
@@ -24,7 +24,6 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-jest": "^21.2.0",
     "css-loader": "^0.28.7",
-    "css-mqpacker": "^6.0.1",
     "eslint": "^4.11.0",
     "eslint-loader": "^1.9.0",
     "extract-text-webpack-plugin": "^3.0.2",


### PR DESCRIPTION
Reverts infielddigital/aem-webpack-example#17
Let's keep `aem-webpack-example` simple and not predefine too many things.