### PR TITLE
adjust babel-loader config to point to a single .babelrc file

### DIFF
--- a/ui.apps/src/main/.babelrc
+++ b/ui.apps/src/main/.babelrc
@@ -1,3 +1,0 @@
-{
-    "extends": "./webpack.core/.babelrc"
-}

--- a/ui.apps/src/main/webpack.core/internals/webpack.config.js
+++ b/ui.apps/src/main/webpack.core/internals/webpack.config.js
@@ -34,6 +34,9 @@ const WEBPACK_DEFAULT = {
       exclude: /node_modules/,
       use: [{
         loader: 'babel-loader',
+        options: {
+          extends : path.resolve(__dirname, '../.babelrc'),
+        },
       }, {
         loader: 'eslint-loader',
         options: {


### PR DESCRIPTION
This webpack.config.js change removes the need for the extra .babelrc config file