### PR TITLE
Make it easier to override default Babel config

### DIFF
--- a/ui.apps/src/main/webpack.core/internals/babel.config.js
+++ b/ui.apps/src/main/webpack.core/internals/babel.config.js
@@ -1,0 +1,9 @@
+const merge = require('merge');
+const CONFIG = require('./../../webpack.project');
+const path = require('path');
+
+const BABEL_DEFAULT = {
+  extends: path.resolve(__dirname, '../.babelrc'),
+};
+
+module.exports = merge.recursive(true, BABEL_DEFAULT, CONFIG.babel);

--- a/ui.apps/src/main/webpack.core/internals/webpack.config.js
+++ b/ui.apps/src/main/webpack.core/internals/webpack.config.js
@@ -34,9 +34,7 @@ const WEBPACK_DEFAULT = {
       exclude: /node_modules/,
       use: [{
         loader: 'babel-loader',
-        options: {
-          extends : path.resolve(__dirname, '../.babelrc'),
-        },
+        options: require('./babel.config.js'),
       }, {
         loader: 'eslint-loader',
         options: {

--- a/ui.apps/src/main/webpack.core/package-lock.json
+++ b/ui.apps/src/main/webpack.core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-core",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/ui.apps/src/main/webpack.core/package.json
+++ b/ui.apps/src/main/webpack.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-core",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "private": true,
   "description": "Core front end setup of a project",
   "scripts": {

--- a/ui.apps/src/main/webpack.project/entries/components.js
+++ b/ui.apps/src/main/webpack.project/entries/components.js
@@ -9,6 +9,7 @@
 const cache = {};
 
 function importAll(r) {
+  // r.keys().forEach((key) => {  // ES6
   r.keys().forEach(function (key) {
     cache[key] = r(key);
     return cache;

--- a/ui.apps/src/main/webpack.project/index.js
+++ b/ui.apps/src/main/webpack.project/index.js
@@ -79,6 +79,17 @@ const STYLELINT = {
 };
 
 /**
+ * BABEL
+ *
+ * You can override or extend the default BABEL configuration using options from
+ * https://babeljs.io/docs/usage/api/#options
+ */
+const BABEL = {
+  // You can set a path to your project-specific .babelrc file as follows:
+  // extends: path.resolve(__dirname, '../.babelrc'),
+};
+
+/**
  * JEST
  *
  * You can override or extend JEST, but you don't have to.
@@ -87,6 +98,7 @@ const JEST = {};
 
 module.exports = {
   aem: AEM,
+  babel: BABEL,
   eslint: ESLINT,
   jest: JEST,
   stylelint: STYLELINT,

--- a/ui.apps/src/main/webpack.project/index.js
+++ b/ui.apps/src/main/webpack.project/index.js
@@ -36,7 +36,7 @@ const WEBPACK = {
  */
 const ESLINT = {
   // Optional: Replace `eslint:recommended` with `eslint-config-infield` and run
-  // `npm install --save-dev eslint-config-infield eslint` for stricter linting rules
+  // `npm install --save-dev eslint-config-infield` for stricter linting rules
   extends: "eslint:recommended",
 
   // If you want to define variables that are available across various processed JavaScript


### PR DESCRIPTION
It's [not possible](https://github.com/babel/babel/issues/4630) to use a JavaScript file instead of a `.babelrc` file, so I had to handle how users can override the default Babel configuration slightly different than how we're doing it for other configs (ESLint, Jest, ...).