### PR TITLE
Update Eslint Configuartion Strategy

### DIFF
--- a/ui.apps/src/main/webpack.core/.eslintrc.js
+++ b/ui.apps/src/main/webpack.core/.eslintrc.js
@@ -1,0 +1,39 @@
+const CONFIG_WEBPACK = require('./internals/webpack.config.js');
+
+module.exports = {
+  env: {
+    browser: true,
+    es6: true,
+    node: true,
+  },
+  // Optional: Replace `eslint:recommended` with `eslint-config-infield` and run
+  // `npm install --save-dev eslint-config-infield` for stricter linting rules
+  extends: "eslint:recommended",
+  parserOptions: {
+    ecmaVersion: 8,
+    sourceType: 'module',
+  },
+  settings: {
+    // This prevents `no-unused-vars` and `import/no-unresolved` from being thrown
+    // when modules are imported that are defined in Webpack but not correctly
+    // resolved by `eslint-plugin-import`. Note that `eslint-plugin-import` can
+    // be defined directly in this project's package.json but it can also be an
+    // dependency of an extended ESLint configuration.
+    'import/resolver': {
+      node: {
+        paths: (CONFIG_WEBPACK.resolve && CONFIG_WEBPACK.resolve.modules) || [],
+      },
+    },
+  },
+
+  // If you want to define variables that are available across various processed JavaScript
+  // files, define them here. More details: http://eslint.org/docs/user-guide/configuring#specifying-globals
+  globals: {
+    $: true,
+    Granite: true,
+  },
+
+  rules: {
+    "no-console" : 1, // 0 = off, 1 = warn, 2 = error
+  }
+}

--- a/ui.apps/src/main/webpack.core/.eslintrc.js
+++ b/ui.apps/src/main/webpack.core/.eslintrc.js
@@ -1,14 +1,14 @@
 const CONFIG_WEBPACK = require('./internals/webpack.config.js');
 
 module.exports = {
+  // Optional: Replace `eslint:recommended` with `eslint-config-infield` and run
+  // `npm install --save-dev eslint-config-infield` for stricter linting rules
+  extends: "eslint:recommended",
   env: {
     browser: true,
     es6: true,
     node: true,
   },
-  // Optional: Replace `eslint:recommended` with `eslint-config-infield` and run
-  // `npm install --save-dev eslint-config-infield` for stricter linting rules
-  extends: "eslint:recommended",
   parserOptions: {
     ecmaVersion: 8,
     sourceType: 'module',

--- a/ui.apps/src/main/webpack.core/internals/eslint.config.js
+++ b/ui.apps/src/main/webpack.core/internals/eslint.config.js
@@ -1,29 +1,9 @@
 const merge = require('merge');
-const CONFIG = require('./../../webpack.project');
-const CONFIG_WEBPACK = require('./webpack.config.js');
+const CONFIG = require('../../webpack.project');
+const path = require('path');
 
 const ESLINT_DEFAULT = {
-  env: {
-    browser: true,
-    es6: true,
-    node: true,
-  },
-  parserOptions: {
-    ecmaVersion: 8,
-    sourceType: 'module',
-  },
-  settings: {
-    // This prevents `no-unused-vars` and `import/no-unresolved` from being thrown
-    // when modules are imported that are defined in Webpack but not correctly
-    // resolved by `eslint-plugin-import`. Note that `eslint-plugin-import` can
-    // be defined directly in this project's package.json but it can also be an
-    // dependency of an extended ESLint configuration.
-    'import/resolver': {
-      node: {
-        paths: (CONFIG_WEBPACK.resolve && CONFIG_WEBPACK.resolve.modules) || [],
-      },
-    },
-  },
+  extends: path.resolve(__dirname, '../.eslintrc.js'),
 };
 
 module.exports = merge.recursive(true, ESLINT_DEFAULT, CONFIG.eslint);

--- a/ui.apps/src/main/webpack.project/index.js
+++ b/ui.apps/src/main/webpack.project/index.js
@@ -45,20 +45,7 @@ const WEBPACK = {
  * as strict as possible.
  */
 const ESLINT = {
-  // Optional: Replace `eslint:recommended` with `eslint-config-infield` and run
-  // `npm install --save-dev eslint-config-infield` for stricter linting rules
-  extends: "eslint:recommended",
-
-  // If you want to define variables that are available across various processed JavaScript
-  // files, define them here. More details: http://eslint.org/docs/user-guide/configuring#specifying-globals
-  globals: {
-    $: true,
-    Granite: true,
-  },
-
-  rules: {
-    "no-console": "off",
-  },
+  // You can override or extend the default ESLINT configuration here
 };
 
 /**


### PR DESCRIPTION
I'm hoping to move toward using more standard "dot file" approach for config files. The biggest benefit of this change is that text editors will now be able to auto-format on save. 

Before this is merged, I need to test how extend/overwrite the base eslint for a from the webpack.project folder.

Once this is finished and merged, next steps are to work out:
+ Add optional Prettier config
+ Create Stylelint dot-config file.
+ Create Jest dot-config config